### PR TITLE
Add connection timeout check

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ I believe it implements all ampy commands except for the --no-output run modifie
 
 The default baud setting of 115200 seems to be the only baud setting the works with ampy. Not sure why that is.
 
+By default, the program will check every 2 minutes if the remote device is still connected. If not, it will automatically disconnect the device.
+
 Any errors are also displayed in the scrollbox.
 
 Prerequisites:
@@ -21,7 +23,17 @@ the directory that you ran the command in. E.g. you're in directory `user/mydir`
 the tree view will open in `user/mydir`.
 
 To also print debug messages to your local terminal, run with:
-`python3 ampy-gui.py debug`
+`python3 ampy-gui.py -d` or `python3 ampy-gui.py --debug`
+
+The following other arguments are available:
+- `-h` or `--help` : prints help info.
+- `-d` or `--debug` : enables debug printing in the console that you ran the script in.
+- `-n` or `--notimeout` : disables device connection timeout checking (if the device does not respond after a certain timeout delay, the connection is automatically broken).
+- `-t <timeout delay>` or `--timedelay <time delay>` : specifies the timeout delay in seconds after which the device connection should be checked. Default delay is 120 seconds.
+
+Example: run the program with debug information, and no timeout checking: `python3 ampy-gui.py -d -n`
+
+Example: run the program with no debug information, and 5 minute timeout checking: `python3 ampy-gui.py -t 300`
 
 Instructions:
 - Plug in your device

--- a/ampy-gui.py
+++ b/ampy-gui.py
@@ -1146,12 +1146,12 @@ if __name__ == "__main__":
 		for opt, arg in opts:
 			if opt in ['-h', '--help']:
 				print("Possible command line arguments:")
-				print("\t-h or --help : prints help info")
-				print("\t-d or --debug : enables debug printing in the console that you ran the script in")
+				print("\t-h or --help : prints help info.")
+				print("\t-d or --debug : enables debug printing in the console that you ran the script in.")
 				print(
-					"\t-n or --notimeout : disables device connection timeout checking (if the device does not respond after a certain timeout delay, the connection is automatically broken)")
+					"\t-n or --notimeout : disables device connection timeout checking (if the device does not respond after a certain timeout delay, the connection is automatically broken).")
 				print(
-					"\t-t <timeout delay> or --timedelay <time delay> : specifies the timeout delay in seconds after which the device connection should be checked. Default delay is 120 seconds.")
+					"\t-t <timeout delay> or --timedelay <time delay> : specifies the timeout delay in seconds after which the device connection should be checked. Default delay is 120 seconds")
 				sys.exit(2)
 			elif opt in ['-d', '--debug']:
 				debug = True

--- a/ampy-gui.py
+++ b/ampy-gui.py
@@ -550,8 +550,7 @@ class AppWindow(Gtk.ApplicationWindow):
 			files.sort(key=lambda v: (v.upper(), v))  # Make sure the files are sorted alphabetically
 		else:
 			error = output.stderr.decode("UTF-8")
-			index = error.find("RuntimeError:")
-			self.debug_print(error[index:])
+			self.print_and_terminal(self.terminal_buffer, "ERROR: " + error, MsgType.ERROR)
 
 		return files
 
@@ -570,8 +569,7 @@ class AppWindow(Gtk.ApplicationWindow):
 			directories.sort(key=lambda v: (v.upper(), v))  # Make sure the directories are sorted alphabetically
 		else:
 			error = output.stderr.decode("UTF-8")
-			index = error.find("RuntimeError:")
-			self.debug_print(error[index:])
+			self.print_and_terminal(self.terminal_buffer, "ERROR: " + error, MsgType.ERROR)
 
 		return directories
 
@@ -730,8 +728,7 @@ class AppWindow(Gtk.ApplicationWindow):
 					output=subprocess.run(self.ampy_command + args, capture_output=True)
 					if output.returncode != 0:
 						error = output.stderr.decode("UTF-8")
-						index = error.find("RuntimeError:")
-						self.print_and_terminal(terminal_buffer, error[index:], MsgType.ERROR)
+						self.print_and_terminal(self.terminal_buffer, "ERROR: " + error, MsgType.ERROR)
 
 				# File deletion done
 				if len(rows_selected) == 1:
@@ -777,8 +774,7 @@ class AppWindow(Gtk.ApplicationWindow):
 					self.populate_remote_tree_model(remote_treeview)
 				else:
 					error = output.stderr.decode("UTF-8")
-					index=error.find("RuntimeError:")
-					self.print_and_terminal(terminal_buffer, error[index:], MsgType.ERROR)
+					self.print_and_terminal(self.terminal_buffer, "ERROR: " + error, MsgType.ERROR)
 
 	def reset_button_clicked(self,button, remote_treeview,terminal_buffer):
 		""" Performs a soft reset/reboot of the remote device.
@@ -792,8 +788,7 @@ class AppWindow(Gtk.ApplicationWindow):
 				self.populate_remote_tree_model(remote_treeview)
 			else:
 				error = output.stderr.decode("UTF-8")
-				index=error.find("RuntimeError:")
-				self.print_and_terminal(terminal_buffer, error[index:], MsgType.ERROR)
+				self.print_and_terminal(self.terminal_buffer, "ERROR: " + error, MsgType.ERROR)
 
 	def run_local_button_clicked(self, button, local_treeview, terminal_buffer):
 		response = self.check_for_device()


### PR DESCRIPTION
This PR adds the feature that the program checks every 2 minutes whether the remote device is still connected. If not, the device will get disconnected.

You can disable this behavior, or change the timeout delay, by adding command line arguments when you run the script (see updated README file).